### PR TITLE
#Update-vs1.0.31-a.1

### DIFF
--- a/Runtime/Async/UnityTask/EditorUnityTaskPool.cs
+++ b/Runtime/Async/UnityTask/EditorUnityTaskPool.cs
@@ -26,7 +26,8 @@ namespace Cobilas.Unity.Utility {
                         break;
                     case PlayModeStateChange.ExitingPlayMode:
                         for (int I = 0; I < ArrayManipulation.ArrayLength(tasks); I++)
-                            tasks[I].Cancel();
+                            if (!tasks[I].IsCancellationRequested && !tasks[I].IsDisposed)
+                                tasks[I].Cancel();
                         break;
                 }
             };


### PR DESCRIPTION
# Cancelamento indevido de tarefa [#ISE0001](https://github.com/BelicusBr/com.cobilas.unity.utility/commit/3ddf6cf814870e65892c97d0d30cb74ba82b4f02)
Após o editor sair para o modo [`PlayModeStateChange.ExitingPlayMode`](https://docs.unity3d.com/ScriptReference/PlayModeStateChange.ExitingPlayMode.html) todas as tarefas assíncronas são canceladas o que pode ocasionar o erro de [`ObjectDisposedException`](https://learn.microsoft.com/en-us/dotnet/api/system.objectdisposedexception?view=netframework-4.7.1).
## Fixed
Agora ao cancelar uma tarefa assíncronas no modo `PlayModeStateChange.ExitingPlayMode` é verificado se a tarefa não foi cancelada e descartada.